### PR TITLE
Have you ever tried to run this code?

### DIFF
--- a/cpp/full_source/centroid.cpp
+++ b/cpp/full_source/centroid.cpp
@@ -17,7 +17,7 @@ int computeSize(int x, int pr = -1) {
     sz[x] = 1;
     for (int to : g[x]) {
         if (to == pr || used[to]) continue;
-        sz[x] += computeSize(to);
+        sz[x] += computeSize(to, x);
     }
     return sz[x];
 }


### PR DESCRIPTION
You've added a 'parent' argument for `computeSize`, but you don't use it. It leads to looping. 
Correct me if I am wrong.